### PR TITLE
Update grabinput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ include = ["src/**/*.rs", "examples/*.rs", "tests/*", "Cargo.toml", "README.md",
 
 [dev-dependencies]
 
-grabinput = "^0.1"
+grabinput = "^0.2"

--- a/examples/pp.rs
+++ b/examples/pp.rs
@@ -5,7 +5,7 @@ use asexp::Sexp;
 use asexp::sexp::prettyprint;
 
 fn main() {
-    let s = grabinput::all(std::env::args().nth(1));
+    let s = grabinput::from_args().with_fallback().all();
     let expr = Sexp::parse_toplevel(&s).unwrap();
     let _ = prettyprint(&expr, &mut std::io::stdout(), 0, false).unwrap();
 }


### PR DESCRIPTION
This appears to be the only published crate on crates.io that depends on grabinput. Since I just threw away the old api with the new version, I thought I'd submit a PR. Shouldn't make any difference to how your pretty print example works.
